### PR TITLE
Use thread ID already available.

### DIFF
--- a/winsup/cygwin/cygthread.cc
+++ b/winsup/cygwin/cygthread.cc
@@ -214,7 +214,7 @@ cygthread::create ()
       if (!htobe)
 	api_fatal ("CreateThread failed for %s - %p<%y>, %E", __name, h, id);
       else
-	SetThreadName (GetThreadId (htobe), __name);
+	SetThreadName (id, __name);
       thread_printf ("created name '%s', thread %p, id %y", __name, h, id);
 #ifdef DEBUGGING
       terminated = false;


### PR DESCRIPTION
Actually, the required value is already returned by CreateThread().
So, there is no need to call GetThreadId() or avoid to get this value from the lpThreadId parameter of CreateThread().