### PR TITLE
Added cygwin_backtrace() with behaviour like in Linux BACKTRACE(3)

### DIFF
--- a/winsup/cygwin/common.din
+++ b/winsup/cygwin/common.din
@@ -391,6 +391,7 @@ cygwin_posix_path_list_p NOSIGFE
 cygwin_set_impersonation_token SIGFE
 cygwin_split_path NOSIGFE
 cygwin_stackdump SIGFE
+cygwin_backtrace SIGFE
 cygwin_umount SIGFE
 cygwin_winpid_to_pid SIGFE
 daemon SIGFE

--- a/winsup/cygwin/exceptions.cc
+++ b/winsup/cygwin/exceptions.cc
@@ -460,6 +460,21 @@ cygwin_stackdump ()
   exc.dumpstack ();
 }
 
+extern "C" int
+cygwin_backtrace (void **array, int size)
+{
+    CONTEXT c;
+    c.ContextFlags = CONTEXT_FULL;
+    RtlCaptureContext (&c);
+
+    thestack.init ((PUINT_PTR) c._GR(bp), 0, &c);
+    int i;
+    for (i = 0; i < size && thestack++; i++)
+        array[i] = (void*)thestack.sf.AddrPC.Offset;
+
+  return i;
+}
+
 #define TIME_TO_WAIT_FOR_DEBUGGER 10000
 
 extern "C" int


### PR DESCRIPTION
Sometimes it's useful to get stack dump in the way we have in in the gnu C lib. Here is implementation. 